### PR TITLE
Remove empty directories created by aggregation.R

### DIFF
--- a/Code/aggregation.R
+++ b/Code/aggregation.R
@@ -20,16 +20,6 @@ if(!dir.exists(paste0('Data/random_ld/chr', ch))){
 if(!dir.exists(paste0('Data/random_ld2/chr', ch))){
   dir.create(paste0('Data/random_ld2/chr', ch))
 }
-for(i in 1:(3*N)){
-  if(!dir.exists(paste0('Data/random_ld/chr', ch, '/', i))){
-    dir.create(paste0('Data/random_ld/chr', ch, '/', i))
-  }
-}
-for(i in 1:(2*N)){
-  if(!dir.exists(paste0('Data/random_ld2/chr', ch, '/', i))){
-    dir.create(paste0('Data/random_ld2/chr', ch, '/', i))
-  }
-}
 
 
 


### PR DESCRIPTION
The script `aggregation.R` creates many subdirectories per chromosome in `Data/` similar to how `random_vector_generation.R` creates many subdirectories per chromosome in `Temp/`. However, as far as I can tell, the directories created in `Data/` are never used.

`aggregation.R` writes its output files directly to the chromosome directory:

https://github.com/ghm17/LOGODetect/blob/f6877934b1b89bd4e63ba2306ffbf11b36de3d44/Code/aggregation.R#L47

https://github.com/ghm17/LOGODetect/blob/f6877934b1b89bd4e63ba2306ffbf11b36de3d44/Code/aggregation.R#L60

And `BiScan_null.R` also ignores those empty subdirectories:

https://github.com/ghm17/LOGODetect/blob/f6877934b1b89bd4e63ba2306ffbf11b36de3d44/Code/BiScan_null.R#L118-L122