### PR TITLE
Remove unused argument mu

### DIFF
--- a/Code/random_vector_generation.R
+++ b/Code/random_vector_generation.R
@@ -38,7 +38,7 @@ for(i in 1:(2*N)){
 
 
 thre = 1000
-rmv = function(n, mu, Sigma){
+rmv = function(n, Sigma){
   SVD = svd(Sigma, nu = 0, nv = nrow(Sigma))
   sv = SVD$d
   p = sum(sv>0)
@@ -63,8 +63,8 @@ ld_diag[[2]] = LD[[1]][(len[1]+1):(len[1]+len[2]), (len[1]+1):(len[1]+len[2])]
 ld2_diag[[1]] = (N0-1)/(N0-2)*( ld_diag[[1]]%*%ld_diag[[1]] + ld_offdiag[[1]]%*%t(ld_offdiag[[1]]) ) - sum(len[1:2])/(N0-2)*ld_diag[[1]]
 ld2_offdiag[[1]] = (N0-1)/(N0-2)*( ld_diag[[1]]%*%ld_offdiag[[1]] + ld_offdiag[[1]]%*%ld_diag[[2]] ) - sum(len[1:2])/(N0-2)*ld_offdiag[[1]]
 
-ss = rmv(3*N, rep(0, len[1]), ld_diag[[1]])
-tt = rmv(2*N, rep(0, len[1]), ld2_diag[[1]])
+ss = rmv(3*N, ld_diag[[1]])
+tt = rmv(2*N, ld2_diag[[1]])
 ss = cbind(1:(3*N), ss)
 tt = cbind(1:(2*N), tt)
 wri_ss = function(dat){
@@ -113,8 +113,8 @@ for(j in 2:(count-1)){
   C2 = t(T12)%*%V2%*%D2%*%t(V2)
   Sigma2 = T22 - C2%*%T12
   
-  ss_new = rmv(3*N, rep(0, len[j]), Sigma1) + ss%*%t(C1)
-  tt_new = rmv(2*N, rep(0, len[j]), Sigma2) + tt%*%t(C2)
+  ss_new = rmv(3*N, Sigma1) + ss%*%t(C1)
+  tt_new = rmv(2*N, Sigma2) + tt%*%t(C2)
   ss = ss_new
   tt = tt_new
   ss = cbind(1:(3*N), ss)
@@ -165,8 +165,8 @@ T12 = ld2_offdiag[[j-1]]
 T22 = ld2_diag[[j]]
 C2 = t(T12)%*%V2%*%D2%*%t(V2)
 Sigma2 = T22 - C2%*%T12
-ss_new = rmv(3*N, rep(0, len[j]), Sigma1) + ss%*%t(C1)
-tt_new = rmv(2*N, rep(0, len[j]), Sigma2) + tt%*%t(C2)
+ss_new = rmv(3*N, Sigma1) + ss%*%t(C1)
+tt_new = rmv(2*N, Sigma2) + tt%*%t(C2)
 ss = ss_new
 tt = tt_new
 ss = cbind(1:(3*N), ss)


### PR DESCRIPTION
The function `rmv()` has an argument `mu` that appears to be unused:

https://github.com/ghm17/LOGODetect/blob/61e39cbc04d69b2bb354672529673a10fcdbb6ac/Code/random_vector_generation.R#L41-L50

A long vector of zeros is passed to `mu` (the same length as the dimensions of `Sigma`), and I did a quick test to convince myself that the argument had no effect:

```
> set.seed(1)
> ss1 = rmv(3*N, rep(0, len[1]), ld_diag[[1]])
> set.seed(1)
> ss2 = rmv(3*N, Sigma = ld_diag[[1]])
> identical(ss1, ss2)
[1] TRUE
```

This PR removes the unused argument `mu` and updates the calls `rmv()` to remove the vector of zeros.